### PR TITLE
feat(repository): add support for centOS repo

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -2,7 +2,8 @@
 # vim: ft=yaml
 ---
 prometheus:
-  pkg: prometheus
+  pkg:
+    name: prometheus
   config_file: /etc/prometheus/prometheus.yml
   service:
     name: prometheus

--- a/prometheus/defaults.yaml
+++ b/prometheus/defaults.yaml
@@ -2,7 +2,16 @@
 # vim: ft=yaml
 ---
 prometheus:
-  pkg: prometheus
+  pkg:
+    name: prometheus
+    use_upstream_repo: False
+    repo:
+      humanname: prometheus
+      name: prometheus
+      comments:
+        - installed by salt
+      enabled: 1
+      gpgcheck: 1
   rootgroup: root
   config_file: /etc/prometheus/prometheus.yml
   config: {}
@@ -12,5 +21,6 @@ prometheus:
     group: prometheus
   exporters:
     node:
-      pkg: prometheus-node-exporter
+      pkg:
+        name: prometheus-node-exporter
       service: prometheus-node-exporter

--- a/prometheus/exporters/node/clean.sls
+++ b/prometheus/exporters/node/clean.sls
@@ -12,7 +12,7 @@ prometheus-exporters-node-service-dead:
 
 prometheus-exporters-node-pkg-removed:
   pkg.removed:
-    - name: {{ prometheus.exporters.node.pkg }}
+    - name: {{ prometheus.exporters.node.pkg.name }}
     - require:
       - service: prometheus-exporters-node-service-dead
 

--- a/prometheus/exporters/node/init.sls
+++ b/prometheus/exporters/node/init.sls
@@ -8,7 +8,7 @@
 
 prometheus-exporters-node-pkg-installed:
   pkg.installed:
-    - name: {{ prometheus.exporters.node.pkg }}
+    - name: {{ prometheus.exporters.node.pkg.name }}
 
 {%- if 'args' in prometheus.exporters.node %}
 {%-   set args = prometheus.exporters.node.get('args', {}) -%}

--- a/prometheus/jinja/macros.jinja
+++ b/prometheus/jinja/macros.jinja
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# vim: ft=jinja
+#
+# Collection of common macros
+
+{%- macro format_kwargs(kwarg) -%}
+
+  {%- filter indent(4) %}
+    {%- for k, v in kwarg|dictsort() %}
+- {{ k }}: {{ v }}
+    {%- endfor %}
+  {%- endfilter %}
+
+{%- endmacro %}

--- a/prometheus/osfamilymap.yaml
+++ b/prometheus/osfamilymap.yaml
@@ -11,6 +11,7 @@
 # osfamilymap: {}
 ---
 {%- if grains.os == 'MacOS' %}
+  {% set macos_user = salt['cmd.run']("stat -f '%Su' /dev/console") %}
   {% set macos_group = salt['cmd.run']("stat -f '%Sg' /dev/console") %}
 {%- endif %}
 
@@ -20,7 +21,13 @@ Debian:
     node:
       config_file: /etc/default/prometheus-node-exporter
 
-RedHat: {}
+RedHat:
+  pkg:
+    use_upstream_repo: True
+    repo:
+      baseurl: 'https://packagecloud.io/prometheus-rpm/release/el/$releasever/$basearch'
+      gpgkey: 'https://packagecloud.io/prometheus-rpm/release/gpgkey gpgkey2=https://raw.githubusercontent.com/lest/prometheus-rpm/master/RPM-GPG-KEY-prometheus-rpm'
+      metadata_expire: 300
 
 Suse: {}
 
@@ -35,7 +42,8 @@ FreeBSD:
   config_file: /usr/local/etc/prometheus.yml
   exporters:
     node:
-      pkg: node_exporter
+      pkg:
+        name: node_exporter
       service: node_exporter
 
 OpenBSD:
@@ -46,4 +54,5 @@ Solaris: {}
 Windows: {}
 
 MacOS:
+  rootuser: {{ macos_user | d('') }}
   rootgroup: {{ macos_group | d('') }}

--- a/prometheus/package/clean.sls
+++ b/prometheus/package/clean.sls
@@ -9,8 +9,13 @@
 include:
   - {{ sls_config_clean }}
 
+    {%- if prometheus.pkg.use_upstream_repo %}
+include:
+  - .repo.clean
+    {%- endif %}
+
 prometheus-package-clean-pkg-removed:
   pkg.removed:
-    - name: {{ prometheus.pkg }}
+    - name: {{ prometheus.pkg.name }}
     - require:
       - sls: {{ sls_config_clean }}

--- a/prometheus/package/repo/clean.sls
+++ b/prometheus/package/repo/clean.sls
@@ -4,12 +4,7 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import prometheus with context %}
- 
-    {%- if prometheus.pkg.use_upstream_repo %}
-include:
-  - .repo
-    {%- endif %}
 
-prometheus-package-install-pkg-installed:
-  pkg.installed:
-    - name: {{ prometheus.pkg.name }}
+prometheus-package-repo-clean-pkgrepo-absent:
+  pkgrepo.absent:
+    - name: {{ prometheus.pkg.repo.name }}

--- a/prometheus/package/repo/init.sls
+++ b/prometheus/package/repo/init.sls
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+include:
+  - .install

--- a/prometheus/package/repo/install.sls
+++ b/prometheus/package/repo/install.sls
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import prometheus with context %}
+
+  {%- if prometheus.pkg.use_upstream_repo %}
+      {%- from tplroot ~ "/jinja/macros.jinja" import format_kwargs with context %}
+
+prometheus-package-repo-install-pkgrepo-managed:
+  pkgrepo.managed:
+    {{- format_kwargs(prometheus.pkg.repo) }}
+
+prometheus-package-repo-install-file-replace-workaround-for-salt-51494:
+  file.replace:
+    - name: /etc/yum.repos.d/prometheus.repo
+    - pattern: ' gpgkey2='
+    - repl: '\n       '
+    - ignore_if_missing: True
+    - onlyif: {{ grains.os_family == 'RedHat' }}
+
+  {%- endif %}


### PR DESCRIPTION
This PR adds support for [prometheus repo](https://github.com/lest/prometheus-rpm#centos-7) on RedHat. The implementation required a workaround for https://github.com/saltstack/salt/issues/51494

BREAKING CHANGE: the variable 'pkg' was renamed 'pkg.name', update your pillars
One state failed due to https://github.com/saltstack-formulas/prometheus-formula/issues/3
```
          ID: prometheus-package-repo-install-pkgrepo-managed
    Function: pkgrepo.managed
        Name: prometheus
      Result: True
     Comment: Configured package repo 'prometheus'
     Started: 00:18:22.735432
    Duration: 466.209 ms
     Changes:   
              ----------
              gpgkey:
                  ----------
                  new:
                      https://packagecloud.io/prometheus-rpm/release/gpgkey gpgkey2=https://raw.githubusercontent.com/lest/prometheus-rpm/master/RPM-GPG-KEY-prometheus-rpm
                  old:
                    
----------
          ID: prometheus-package-repo-install-pkgrepo-workaround-salt-51494
    Function: file.replace
        Name: /etc/yum.repos.d/prometheus.repo
      Result: True
     Comment: Changes were made
     Started: 00:18:23.203215
    Duration: 469.286 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -1,7 +1,8 @@
                   [prometheus]
                   metadata_expire=300
                   name=prometheus
                  -gpgkey=https://packagecloud.io/prometheus-rpm/release/gpgkey gpgkey2=https://raw.githubusercontent.com/lest/prometheus-rpm/master/RPM-GPG-KEY-prometheus-rpm
                  +gpgkey=https://packagecloud.io/prometheus-rpm/release/gpgkey
                  +       https://raw.githubusercontent.com/lest/prometheus-rpm/master/RPM-GPG-KEY-prometheus-rpm
                   enabled=1
                   baseurl=https://packagecloud.io/prometheus-rpm/release/el/$releasever/$basearch
----------
          ID: prometheus-package-install-pkg-installed
    Function: pkg.installed
        Name: prometheus
      Result: True
     Comment: The following packages were installed/updated: prometheus
     Started: 00:18:23.680809
    Duration: 35420.618 ms
     Changes:   
              ----------
              gpg-pubkey.(none):
                  ----------
                  new:
                      168a1ea1-58138084,352c64e5-52ae6884,7457ccd1-58071431,de57bfbe-53a9be98,f4a80eb5-53a7ff4b
                  old:
                      352c64e5-52ae6884,7457ccd1-58071431,de57bfbe-53a9be98,f4a80eb5-53a7ff4b
              prometheus:
                  ----------
                  new:
                      1.8.2-1.el7.centos
                  old:
----------
          ID: prometheus-config-file-file-managed
    Function: file.managed
        Name: /etc/prometheus/prometheus.yml
      Result: True
     Comment: File /etc/prometheus/prometheus.yml updated
     Started: 00:18:59.106292
    Duration: 130.952 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -1,27 +1,6 @@
                  -# my global config
                  -global:
                  -  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
                  -  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
                  -  # scrape_timeout is set to the global default (10s).
                  +########################################################################
                  +# File managed by Salt at <salt://prometheus/files/default/prometheus.yml.jinja>.
                  +# Your changes will be overwritten.
                  +########################################################################
                   
                  -  # Attach these labels to any time series or alerts when communicating with
                  -  # external systems (federation, remote storage, Alertmanager).
                  -  external_labels:
                  -      monitor: 'codelab-monitor'
                  -
                  -# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
                  -rule_files:
                  -  # - "first.rules"
                  -  # - "second.rules"
                  -
                  -# A scrape configuration containing exactly one endpoint to scrape:
                  -# Here it's Prometheus itself.
                  -scrape_configs:
                  -  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
                  -  - job_name: 'prometheus'
                  -
                  -    # metrics_path defaults to '/metrics'
                  -    # scheme defaults to 'http'.
                  -
                  -    static_configs:
                  -      - targets: ['localhost:9090']
                  +{}
----------
          ID: prometheus-service-running-service-running
    Function: service.running
        Name: prometheus
      Result: False
     Comment: The following requisites were not found:
                                 require:
                                     sls: prometheus.config.args
```