### PR TITLE
 fix(alternatives): fix requisite

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -155,4 +155,4 @@ prometheus:
 
   linux:
     #'Alternatives system' priority: zero disables (default)
-    altpriority: 0
+    altpriority: {{ range(1, 9100000) | random }}

--- a/prometheus/archive/alternatives/install.sls
+++ b/prometheus/archive/alternatives/install.sls
@@ -33,14 +33,12 @@ prometheus-archive-alternatives-install-{{ name }}-home-alternatives-install:
     - order: 10
     - watch:
         - archive: prometheus-archive-install-{{ name }}-archive-extracted
-    - onlyif: {{ grains.os_family not in ('Suse',) }}
 
 prometheus-archive-alternatives-install-{{ name }}-home-alternatives-set:
   alternatives.set:
     - name: prometheus-{{ name }}-home
     - path: {{ p.dir.basedir }}/{{ bundle }}
     - require:
-      - cmd: prometheus-archive-alternatives-install-{{ name }}-home-cmd-run
       - alternatives: prometheus-archive-alternatives-install-{{ name }}-home-alternatives-install
 
            {%- endif %}
@@ -49,7 +47,6 @@ prometheus-archive-alternatives-install-{{ name }}-home-alternatives-set:
 
 prometheus-archive-alternatives-install-{{ name }}-cmd-run-{{ b }}-alternative:
   cmd.run:
-    - onlyif: {{ grains.os_family in ('Suse',) }}
     - name: update-alternatives --install /usr/local/bin/{{ b }} prometheus-{{ name }}-{{ b }} {{ p.dir.basedir }}/{{ bundle }}/{{ b }} {{ p.linux.altpriority }}
     - require:
       - cmd: prometheus-archive-alternatives-install-{{ name }}-home-cmd-run

--- a/prometheus/archive/init.sls
+++ b/prometheus/archive/init.sls
@@ -9,8 +9,6 @@
 
 include:
   - .install
-        {%- if grains.kernel|lower == 'linux' %}
   - .alternatives
-        {%- endif %}
 
     {%- endif %}


### PR DESCRIPTION
This PR fixes an error when linux alternatives is enabled.
```
          ID: prometheus-archive-alternatives-install-prometheus-home-alternatives-set
    Function: alternatives.set
        Name: prometheus-prometheus-home
      Result: False
     Comment: The following requisites were not found:
                                 require:
                                     cmd: prometheus-archive-alternatives-install-prometheus-home-alternatives-install
```

Verified on Ubuntu.