### PR TITLE
fix filename in /etc/default for debian family

### DIFF
--- a/prometheus/config/args/clean.sls
+++ b/prometheus/config/args/clean.sls
@@ -48,7 +48,7 @@ prometheus-config-args-{{ name }}-all:
 
 prometheus-config-args-{{ name }}-file-absent:
   file.absent:
-    - name: {{ prometheus.dir.args }}/{{ name }}.sh
+    - name: {{ prometheus.dir.args }}/{{ name }}{{ '' if grains.os_family == 'Debian' else '.sh' }}
     - require:
       - service: prometheus-service-clean-{{ name }}-service-dead
     - require_in:

--- a/prometheus/config/args/clean.sls
+++ b/prometheus/config/args/clean.sls
@@ -45,10 +45,15 @@ prometheus-config-args-{{ name }}-all:
       - service: prometheus-service-clean-{{ name }}-service-dead
 
             {%- elif grains.os_family != 'FreeBSD' %}
+              {%- if grains.os_family == 'Debian' %}
+                {%- set config_file_name = '{{ prometheus.dir.args }}/{{ name }}' %}
+              {%- else %}
+                {%- set config_file_name = '{{ prometheus.dir.args }}/{{ name }}.sh' %}
+              {%- endif %}
 
 prometheus-config-args-{{ name }}-file-absent:
   file.absent:
-    - name: {{ prometheus.dir.args }}/{{ name }}{{ '' if grains.os_family == 'Debian' else '.sh' }}
+    - name: {{ config_file_name }}
     - require:
       - service: prometheus-service-clean-{{ name }}-service-dead
     - require_in:

--- a/prometheus/config/args/clean.sls
+++ b/prometheus/config/args/clean.sls
@@ -46,9 +46,9 @@ prometheus-config-args-{{ name }}-all:
 
             {%- elif grains.os_family != 'FreeBSD' %}
               {%- if grains.os_family == 'Debian' %}
-                {%- set config_file_name = '{{ prometheus.dir.args }}/{{ name }}' %}
+                {%- set config_file_name = '{}/{}'.format(prometheus.dir.args, name) %}
               {%- else %}
-                {%- set config_file_name = '{{ prometheus.dir.args }}/{{ name }}.sh' %}
+                {%- set config_file_name = '{}/{}.sh'.format(prometheus.dir.args, name) %}
               {%- endif %}
 
 prometheus-config-args-{{ name }}-file-absent:

--- a/prometheus/config/args/install.sls
+++ b/prometheus/config/args/install.sls
@@ -93,10 +93,15 @@ prometheus-config-args-{{ name }}-all:
       - file: prometheus-config-file-args-file-directory
 
             {%- elif grains.os_family != 'FreeBSD' %}
+              {%- if grains.os_family == 'Debian' %}
+                {%- set config_file_name = '{{ prometheus.dir.args }}/{{ name }}' %}
+              {%- else %}
+                {%- set config_file_name = '{{ prometheus.dir.args }}/{{ name }}.sh' %}
+              {%- endif %}
 
 prometheus-config-args-{{ name }}-file-managed:
   file.managed:
-    - name: {{ prometheus.dir.args }}/{{ name }}{{ '' if grains.os_family == 'Debian' else '.sh' }}
+    - name: {{ config_file_name }}
     - contents: |
         ARGS="{{ concat_args(args) }}"
     - watch_in:

--- a/prometheus/config/args/install.sls
+++ b/prometheus/config/args/install.sls
@@ -94,9 +94,9 @@ prometheus-config-args-{{ name }}-all:
 
             {%- elif grains.os_family != 'FreeBSD' %}
               {%- if grains.os_family == 'Debian' %}
-                {%- set config_file_name = '{{ prometheus.dir.args }}/{{ name }}' %}
+                {%- set config_file_name = '{}/{}'.format(prometheus.dir.args, name) %}
               {%- else %}
-                {%- set config_file_name = '{{ prometheus.dir.args }}/{{ name }}.sh' %}
+                {%- set config_file_name = '{}/{}.sh'.format(prometheus.dir.args, name) %}
               {%- endif %}
 
 prometheus-config-args-{{ name }}-file-managed:

--- a/prometheus/config/args/install.sls
+++ b/prometheus/config/args/install.sls
@@ -96,7 +96,7 @@ prometheus-config-args-{{ name }}-all:
 
 prometheus-config-args-{{ name }}-file-managed:
   file.managed:
-    - name: {{ prometheus.dir.args }}/{{ name }}.sh
+    - name: {{ prometheus.dir.args }}/{{ name }}{{ '' if grains.os_family == 'Debian' else '.sh' }}
     - contents: |
         ARGS="{{ concat_args(args) }}"
     - watch_in:


### PR DESCRIPTION
Debian doesn't read /etc/default/prometheus.sh, so config saved by prometheus.config.args.install is not used