### PR TITLE
FreeBSD support restored; textfile collectors; some bugfixes

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -123,3 +123,9 @@ This state will uninstall the prometheus linux alternatives for archives only.
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This state will uninstall the prometheus upstream package repository only.
+
+``prometheus.config.node_exporter.textfile_collectors``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This state will manage the node exporter's textfile collectors
+according to Pillar ``prometheus:exporters:node_exporter:textfile_collectors``.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -123,10 +123,3 @@ This state will uninstall the prometheus linux alternatives for archives only.
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This state will uninstall the prometheus upstream package repository only.
-
-``prometheus.exporters``
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-This state will manage prometheus exporters according to Pillar ``prometheus:exporters``.
-It includes sub-states like ``prometheus.exporters.node``.
-If you don't want to use Pillar data for this you may use the sub-states directly.

--- a/pillar.example
+++ b/pillar.example
@@ -7,7 +7,7 @@ prometheus:
          {%- if grains.os_family not in ('Debian',) %}
     - alertmanager
          {%- endif %}
-    - node_explorer
+    - node_exporter
     # no memcached_exporter in upstream repo - only archive
     # memcached_exporter
 

--- a/pillar.example
+++ b/pillar.example
@@ -173,3 +173,8 @@ prometheus:
           # You must enable individual collectors
           enable: true
           # pkg: ipmitool
+        smartmon:
+          enable: true
+          # pkg: smartmontools
+          # bash_pkg: bash
+          # smartctl: /usr/sbin/smartctl

--- a/pillar.example
+++ b/pillar.example
@@ -168,4 +168,8 @@ prometheus:
 
   exporters:
     node_exporter:
-      textfile_collectors: {}
+      textfile_collectors:
+        ipmitool:
+          # You must enable individual collectors
+          enable: true
+          # pkg: ipmitool

--- a/pillar.example
+++ b/pillar.example
@@ -35,6 +35,7 @@ prometheus:
     node_exporter:
       args:
         web.listen-address: ":9110"
+        # collector.textfile.directory: /var/tmp/node_exporter
 
   tofs:
     # The files_switch key serves as a selector for alternative
@@ -164,3 +165,7 @@ prometheus:
     # 'Alternatives system' priority: zero disables (default)
     # yamllint disable-line rule:braces
     altpriority: {{ range(1, 9100000) | random }}
+
+  exporters:
+    node_exporter:
+      textfile_collectors: {}

--- a/prometheus/config/clean.sls
+++ b/prometheus/config/clean.sls
@@ -5,3 +5,4 @@ include:
   - .file.clean
   - .args.clean
   - .users.clean
+  - .node_exporter.textfile_collectors.clean

--- a/prometheus/config/file/install.sls
+++ b/prometheus/config/file/install.sls
@@ -16,8 +16,8 @@ include:
 prometheus-config-file-etc-file-directory:
   file.directory:
     - name: {{ prometheus.dir.etc }}
-    - user: prometheus
-    - group: prometheus
+    - user: root
+    - group: {{ prometheus.rootgroup }}
     - mode: 755
     - makedirs: True
     - require:

--- a/prometheus/config/init.sls
+++ b/prometheus/config/init.sls
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import prometheus with context %}
+
 include:
   - .users
   - .args
   - .file
+    {%- if 'node_exporter' in prometheus.wanted %}
+  - .node_exporter.textfile_collectors
+    {%- endif %}

--- a/prometheus/config/node_exporter/textfile_collectors/clean.sls
+++ b/prometheus/config/node_exporter/textfile_collectors/clean.sls
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import prometheus with context %}
+
+prometheus-node_exporter-textfile_collectors-dir:
+  file.absent:
+    - name: {{ prometheus.dir.textfile_collectors }}
+
+prometheus-node_exporter-textfile-dir:
+  file.absent:
+    - name: {{ prometheus.service.node_exporter.args.get('collector.textfile.directory') }}
+
+{%- for collector, config in prometheus.get('exporters', {}).get('node_exporter', {}).get('textfile_collectors', {}).items() %}
+include:
+  - .{{ collector }}.clean
+{%- endfor %}
+

--- a/prometheus/config/node_exporter/textfile_collectors/files/ipmitool
+++ b/prometheus/config/node_exporter/textfile_collectors/files/ipmitool
@@ -1,0 +1,91 @@
+#!/usr/bin/awk -f
+
+# Source: https://github.com/prometheus/node_exporter/blob/master/text_collector_examples/ipmitool
+
+#
+# Converts output of `ipmitool sensor` to prometheus format.
+#
+# With GNU awk:
+#   ipmitool sensor | ./ipmitool > ipmitool.prom
+#
+# With BSD awk:
+#   ipmitool sensor | awk -f ./ipmitool > ipmitool.prom
+#
+
+function export(values, name) {
+	if (values["metric_count"] < 1) {
+		return
+	}
+	delete values["metric_count"]
+
+	printf("# HELP %s%s %s sensor reading from ipmitool\n", namespace, name, help[name]);
+	printf("# TYPE %s%s gauge\n", namespace, name);
+	for (sensor in values) {
+		printf("%s%s{sensor=\"%s\"} %f\n", namespace, name, sensor, values[sensor]);
+	}
+}
+
+# Fields are Bar separated, with space padding.
+BEGIN {
+	FS = "[ ]*[|][ ]*";
+	namespace = "node_ipmi_";
+
+	# Friendly description of the type of sensor for HELP.
+	help["temperature_celsius"] = "Temperature";
+	help["volts"] = "Voltage";
+	help["power_watts"] = "Power";
+	help["speed_rpm"] = "Fan";
+	help["status"] = "Chassis status";
+
+	temperature_celsius["metric_count"] = 0;
+	volts["metric_count"] = 0;
+	power_watts["metric_count"] = 0;
+	speed_rpm["metric_count"] = 0;
+	status["metric_count"] = 0;
+}
+
+# Not a valid line.
+{
+	if (NF < 3) {
+		next
+	}
+}
+
+# $2 is value field.
+$2 ~ /na/ {
+	next
+}
+
+# $3 is type field.
+$3 ~ /degrees C/ {
+	temperature_celsius[$1] = $2;
+	temperature_celsius["metric_count"]++;
+}
+
+$3 ~ /Volts/ {
+	volts[$1] = $2;
+	volts["metric_count"]++;
+}
+
+$3 ~ /Watts/ {
+	power_watts[$1] = $2;
+	power_watts["metric_count"]++;
+}
+
+$3 ~ /RPM/ {
+	speed_rpm[$1] = $2;
+	speed_rpm["metric_count"]++;
+}
+
+$3 ~ /discrete/ {
+	status[$1] = $2;
+	status["metric_count"]++;
+}
+
+END {
+	export(temperature_celsius, "temperature_celsius");
+	export(volts, "volts");
+	export(power_watts, "power_watts");
+	export(speed_rpm, "speed_rpm");
+	export(status, "status");
+}

--- a/prometheus/config/node_exporter/textfile_collectors/files/smartmon.sh.jinja
+++ b/prometheus/config/node_exporter/textfile_collectors/files/smartmon.sh.jinja
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Script informed by the collectd monitoring script for smartmontools (using smartctl)
+# by Samuel B. <samuel_._behan_(at)_dob_._sk> (c) 2012
+# source at: http://devel.dob.sk/collectd-scripts/
+
+# TODO: This probably needs to be a little more complex.  The raw numbers can have more
+#       data in them than you'd think.
+#       http://arstechnica.com/civis/viewtopic.php?p=22062211
+
+# Formatting done via shfmt -i 2
+# https://github.com/mvdan/sh
+
+parse_smartctl_attributes_awk="$(
+  cat <<'SMARTCTLAWK'
+$1 ~ /^ *[0-9]+$/ && $2 ~ /^[a-zA-Z0-9_-]+$/ {
+  gsub(/-/, "_");
+  printf "%s_value{{ '{' }}%s,smart_id=\"%s\"} %d\n", $2, labels, $1, $4
+  printf "%s_worst{{ '{' }}%s,smart_id=\"%s\"} %d\n", $2, labels, $1, $5
+  printf "%s_threshold{{ '{' }}%s,smart_id=\"%s\"} %d\n", $2, labels, $1, $6
+  printf "%s_raw_value{{ '{' }}%s,smart_id=\"%s\"} %e\n", $2, labels, $1, $10
+}
+SMARTCTLAWK
+)"
+
+smartmon_attrs="$(
+  cat <<'SMARTMONATTRS'
+airflow_temperature_cel
+command_timeout
+current_pending_sector
+end_to_end_error
+erase_fail_count
+g_sense_error_rate
+hardware_ecc_recovered
+host_reads_mib
+host_reads_32mib
+host_writes_mib
+host_writes_32mib
+load_cycle_count
+media_wearout_indicator
+wear_leveling_count
+nand_writes_1gib
+offline_uncorrectable
+power_cycle_count
+power_on_hours
+program_fail_count
+raw_read_error_rate
+reallocated_event_count
+reallocated_sector_ct
+reported_uncorrect
+sata_downshift_count
+seek_error_rate
+spin_retry_count
+spin_up_time
+start_stop_count
+temperature_case
+temperature_celsius
+temperature_internal
+total_lbas_read
+total_lbas_written
+udma_crc_error_count
+unsafe_shutdown_count
+workld_host_reads_perc
+workld_media_wear_indic
+workload_minutes
+SMARTMONATTRS
+)"
+smartmon_attrs="$(echo ${smartmon_attrs} | xargs | tr ' ' '|')"
+
+parse_smartctl_attributes() {
+  local disk="$1"
+  local disk_type="$2"
+  local labels="disk=\"${disk}\",type=\"${disk_type}\""
+  local vars="$(echo "${smartmon_attrs}" | xargs | tr ' ' '|')"
+  sed 's/^ \+//g' |
+    awk -v labels="${labels}" "${parse_smartctl_attributes_awk}" 2>/dev/null |
+    tr A-Z a-z |
+    grep -E "(${smartmon_attrs})"
+}
+
+parse_smartctl_scsi_attributes() {
+  local disk="$1"
+  local disk_type="$2"
+  local labels="disk=\"${disk}\",type=\"${disk_type}\""
+  while read line; do
+    attr_type="$(echo "${line}" | tr '=' ':' | cut -f1 -d: | sed 's/^ \+//g' | tr ' ' '_')"
+    attr_value="$(echo "${line}" | tr '=' ':' | cut -f2 -d: | sed 's/^ \+//g')"
+    case "${attr_type}" in
+    number_of_hours_powered_up_) power_on="$(echo "${attr_value}" | awk '{ printf "%e\n", $1 }')" ;;
+    Current_Drive_Temperature) temp_cel="$(echo ${attr_value} | cut -f1 -d' ' | awk '{ printf "%e\n", $1 }')" ;;
+    Blocks_read_from_cache_and_sent_to_initiator_) lbas_read="$(echo ${attr_value} | awk '{ printf "%e\n", $1 }')" ;;
+    Accumulated_start-stop_cycles) power_cycle="$(echo ${attr_value} | awk '{ printf "%e\n", $1 }')" ;;
+    Elements_in_grown_defect_list) grown_defects="$(echo ${attr_value} | awk '{ printf "%e\n", $1 }')" ;;
+    esac
+  done
+  [ ! -z "$power_on" ] && echo "power_on_hours_raw_value{${labels},smart_id=\"9\"} ${power_on}"
+  [ ! -z "$temp_cel" ] && echo "temperature_celsius_raw_value{${labels},smart_id=\"194\"} ${temp_cel}"
+  [ ! -z "$lbas_read" ] && echo "total_lbas_read_raw_value{${labels},smart_id=\"242\"} ${lbas_read}"
+  [ ! -z "$power_cycle" ] && echo "power_cycle_count_raw_value{${labels},smart_id=\"12\"} ${power_cycle}"
+  [ ! -z "$grown_defects" ] && echo "grown_defects_count_raw_value{${labels},smart_id=\"12\"} ${grown_defects}"
+}
+
+parse_smartctl_info() {
+  local -i smart_available=0 smart_enabled=0 smart_healthy=0
+  local disk="$1" disk_type="$2"
+  local model_family='' device_model='' serial_number='' fw_version='' vendor='' product='' revision='' lun_id=''
+  while read line; do
+    info_type="$(echo "${line}" | cut -f1 -d: | tr ' ' '_')"
+    info_value="$(echo "${line}" | cut -f2- -d: | sed 's/^ \+//g' | sed 's/"/\\"/')"
+    case "${info_type}" in
+    Model_Family) model_family="${info_value}" ;;
+    Device_Model) device_model="${info_value}" ;;
+    Serial_Number) serial_number="${info_value}" ;;
+    Firmware_Version) fw_version="${info_value}" ;;
+    Vendor) vendor="${info_value}" ;;
+    Product) product="${info_value}" ;;
+    Revision) revision="${info_value}" ;;
+    Logical_Unit_id) lun_id="${info_value}" ;;
+    esac
+    if [[ "${info_type}" == 'SMART_support_is' ]]; then
+      case "${info_value:0:7}" in
+      Enabled) smart_enabled=1 ;;
+      Availab) smart_available=1 ;;
+      Unavail) smart_available=0 ;;
+      esac
+    fi
+    if [[ "${info_type}" == 'SMART_overall-health_self-assessment_test_result' ]]; then
+      case "${info_value:0:6}" in
+      PASSED) smart_healthy=1 ;;
+      esac
+    elif [[ "${info_type}" == 'SMART_Health_Status' ]]; then
+      case "${info_value:0:2}" in
+      OK) smart_healthy=1 ;;
+      esac
+    fi
+  done
+  echo "device_info{\
+disk=\"${disk}\",\
+type=\"${disk_type}\",\
+vendor=\"${vendor}\",\
+product=\"${product}\",\
+revision=\"${revision}\",\
+lun_id=\"${lun_id}\",\
+model_family=\"${model_family}\",\
+device_model=\"${device_model}\",\
+serial_number=\"${serial_number}\",\
+firmware_version=\"${fw_version}\"\
+} 1"
+  echo "device_smart_available{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_available}"
+  echo "device_smart_enabled{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_enabled}"
+  echo "device_smart_healthy{disk=\"${disk}\",type=\"${disk_type}\"} ${smart_healthy}"
+}
+
+output_format_awk="$(
+  cat <<'OUTPUTAWK'
+BEGIN { v = "" }
+v != $1 {
+  print "# HELP smartmon_" $1 " SMART metric " $1;
+  print "# TYPE smartmon_" $1 " gauge";
+  v = $1
+}
+{print "smartmon_" $0}
+OUTPUTAWK
+)"
+
+format_output() {
+  sort |
+    awk -F'{' "${output_format_awk}"
+}
+
+smartctl_version="$({{ smartctl }} -V | head -n1 | awk '$1 == "smartctl" {print $2}')"
+
+echo "smartctl_version{version=\"${smartctl_version}\"} 1" | format_output
+
+if [[ "$(expr "${smartctl_version}" : '\([0-9]*\)\..*')" -lt 6 ]]; then
+  exit
+fi
+
+device_list="$({{ smartctl }} --scan-open | awk '/^\/dev/{print $1 "|" $3}')"
+
+for device in ${device_list}; do
+  disk="$(echo ${device} | cut -f1 -d'|')"
+  type="$(echo ${device} | cut -f2 -d'|')"
+  active=1
+  echo "smartctl_run{disk=\"${disk}\",type=\"${type}\"}" "$(TZ=UTC date '+%s')"
+  # Check if the device is in a low-power mode
+  {{ smartctl }} -n standby -d "${type}" "${disk}" > /dev/null || active=0
+  echo "device_active{disk=\"${disk}\",type=\"${type}\"}" "${active}"
+  # Skip further metrics to prevent the disk from spinning up
+  test ${active} -eq 0 && continue
+  # Get the SMART information and health
+  {{ smartctl }} -i -H -d "${type}" "${disk}" | parse_smartctl_info "${disk}" "${type}"
+  # Get the SMART attributes
+  case ${type} in
+  atacam) {{ smartctl }} -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}" ;;
+  sat) {{ smartctl }} -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}" ;;
+  sat+megaraid*) {{ smartctl }} -A -d "${type}" "${disk}" | parse_smartctl_attributes "${disk}" "${type}" ;;
+  scsi) {{ smartctl }} -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
+  megaraid*) {{ smartctl }} -A -d "${type}" "${disk}" | parse_smartctl_scsi_attributes "${disk}" "${type}" ;;
+  *)
+    echo "disk type is not sat, scsi or megaraid but ${type}"
+    exit
+    ;;
+  esac
+done | format_output

--- a/prometheus/config/node_exporter/textfile_collectors/init.sls
+++ b/prometheus/config/node_exporter/textfile_collectors/init.sls
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import prometheus with context %}
+
+prometheus-node_exporter-textfile_collectors-dir:
+  file.directory:
+    - name: {{ prometheus.dir.textfile_collectors }}
+    - mode: 755
+    - user: node_exporter
+    - group: node_exporter
+    - makedirs: True
+
+prometheus-node_exporter-textfile-dir:
+  file.directory:
+    - name: {{ prometheus.service.node_exporter.args.get('collector.textfile.directory') }}
+    - mode: 755
+    - user: node_exporter
+    - group: node_exporter
+    - makedirs: True
+
+{%- set states = [] %}
+{%- for collector, config in prometheus.get('exporters', {}).get('node_exporter', {}).get('textfile_collectors', {}).items() %}
+{%-     if config.get('enable', False) %}
+{%-         if config.get('remove', False) %}
+{%-             set state = ".{}.clean".format(collector) %}
+{%-         else %}
+{%-             set state = ".{}".format(collector) %}
+{%-         endif %}
+{%-         do states.append(state) %}
+{%-     endif %}
+{%- endfor %}
+
+
+{%- if states|length > 0 %}
+prometheus-node_exporter-textfile-dependencies:
+  pkg.installed:
+    - pkgs: {{ prometheus.exporters.node_exporter.textfile_collectors_dependencies }}
+    - require_in:
+{%-     for state in states %}
+      - sls: prometheus.config.node_exporter.textfile_collectors{{ state }}
+{%-     endfor %}
+
+include:
+{%-     for state in states %}
+  - {{ state }}
+{%      endfor %}
+{%- endif %}

--- a/prometheus/config/node_exporter/textfile_collectors/ipmitool/clean.sls
+++ b/prometheus/config/node_exporter/textfile_collectors/ipmitool/clean.sls
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import prometheus with context %}
+
+{%- set config = prometheus.exporters.node_exporter.textfile_collectors.ipmitool %}
+{%- set dir = prometheus.service.node_exporter.args.get('collector.textfile.directory') %}
+{%- set script = prometheus.dir.textfile_collectors ~ '/ipmitool' %}
+
+prometheus-exporters-node-textfile_collectors-ipmitool-pkg:
+  pkg.removed:
+    - name: {{ config.pkg }}
+
+prometheus-exporters-node-textfile_collectors-ipmitool-script:
+  file.absent:
+    - name: {{ script }}
+
+prometheus-exporters-node-textfile_collectors-ipmitool-output:
+  file.absent:
+    - name: {{ dir }}/ipmitool.prom
+
+prometheus-exporters-node-textfile_collectors-ipmitool-cronjob:
+  cron.absent:
+    - identifier: prometheus-exporters-node-textfile_collectors-ipmitool-cronjob

--- a/prometheus/config/node_exporter/textfile_collectors/ipmitool/init.sls
+++ b/prometheus/config/node_exporter/textfile_collectors/ipmitool/init.sls
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import prometheus with context %}
+
+{%- set config = prometheus.exporters.node_exporter.textfile_collectors.ipmitool %}
+{%- set dir = prometheus.service.node_exporter.args.get('collector.textfile.directory') %}
+{%- set script = prometheus.dir.textfile_collectors ~ '/ipmitool' %}
+{%- set cmd_prefix = 'awk -f ' if grains.os_family in ['FreeBSD'] else '' %}
+
+prometheus-exporters-node-textfile_collectors-ipmitool-pkg:
+  pkg.installed:
+    - name: {{ config.pkg }}
+
+prometheus-exporters-node-textfile_collectors-ipmitool-script:
+  file.managed:
+    - name: {{ script }}
+    - source: salt://prometheus/config/node_exporter/textfile_collectors/files/ipmitool
+    - mode: 755
+    - require:
+      - file: prometheus-node_exporter-textfile_collectors-dir
+
+prometheus-exporters-node-textfile_collectors-ipmitool-cronjob:
+  cron.present:
+    - identifier: prometheus-exporters-node-textfile_collectors-ipmitool-cronjob
+    - name: cd {{ dir }} && LANG=C ipmitool sensor | {{ cmd_prefix }}{{ script }} > .ipmitool.prom$$; mv .ipmitool.prom$$ ipmitool.prom
+    - minute: "{{ config.get('minute', '*') }}"
+    - comment: Prometheus' node_exporter's ipmitool textfile collector
+    - require:
+      - file: prometheus-exporters-node-textfile_collectors-ipmitool-script

--- a/prometheus/config/node_exporter/textfile_collectors/smartmon/clean.sls
+++ b/prometheus/config/node_exporter/textfile_collectors/smartmon/clean.sls
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import prometheus with context %}
+
+{%- set config = prometheus.exporters.node_exporter.textfile_collectors.smartmon %}
+{%- set dir = prometheus.service.node_exporter.args.get('collector.textfile.directory') %}
+{%- set script = prometheus.dir.textfile_collectors ~ '/smartmon.sh' %}
+
+prometheus-exporters-node-textfile_collectors-smartmon-pkg:
+  pkg.removed:
+    - name: {{ config.pkg }}
+
+prometheus-exporters-node-textfile_collectors-smartmon-script:
+  file.absent:
+    - name: {{ script }}
+
+prometheus-exporters-node-textfile_collectors-smartmon-output:
+  file.absent:
+    - name: {{ dir }}/smartmon.prom
+
+prometheus-exporters-node-textfile_collectors-smartmon-cronjob:
+  cron.absent:
+    - identifier: prometheus-exporters-node-textfile_collectors-smartmon-cronjob

--- a/prometheus/config/node_exporter/textfile_collectors/smartmon/init.sls
+++ b/prometheus/config/node_exporter/textfile_collectors/smartmon/init.sls
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import prometheus with context %}
+
+{%- set config = prometheus.exporters.node_exporter.textfile_collectors.smartmon %}
+{%- set dir = prometheus.service.node_exporter.args.get('collector.textfile.directory') %}
+{%- set script = prometheus.dir.textfile_collectors ~ '/smartmon.sh' %}
+
+prometheus-exporters-node-textfile_collectors-smartmon-pkg:
+  pkg.installed:
+    - name: {{ config.pkg }}
+
+prometheus-exporters-node-textfile_collectors-smartmon-pkg-bash:
+  pkg.installed:
+    - name: {{ config.bash_pkg }}
+
+prometheus-exporters-node-textfile_collectors-smartmon-script:
+  file.managed:
+    - name: {{ script }}
+    - source: salt://prometheus/config/node_exporter/textfile_collectors/files/smartmon.sh.jinja
+    - template: jinja
+    - context:
+        smartctl: {{ config.smartctl }}
+    - mode: 755
+    - require:
+      - file: prometheus-node_exporter-textfile_collectors-dir
+
+prometheus-exporters-node-textfile_collectors-smartmon-cronjob:
+  cron.present:
+    - identifier: prometheus-exporters-node-textfile_collectors-smartmon-cronjob
+    - name: cd {{ dir }} && LANG=C {{ script }} > .smartmon.prom$$ && mv .smartmon.prom$$ smartmon.prom
+    - minute: "{{ config.get('minute', '*') }}"
+    - comment: Prometheus' node_exporter's smartmon textfile collector
+    - require:
+      - file: prometheus-exporters-node-textfile_collectors-smartmon-script

--- a/prometheus/defaults.yaml
+++ b/prometheus/defaults.yaml
@@ -122,4 +122,8 @@ prometheus:
   exporters:
     node_exporter:
       textfile_collectors_dependencies: []
-      textfile_collectors: {}
+      textfile_collectors:
+        ipmitool:
+          enable: false
+          remove: false
+          pkg: ipmitool

--- a/prometheus/defaults.yaml
+++ b/prometheus/defaults.yaml
@@ -127,3 +127,9 @@ prometheus:
           enable: false
           remove: false
           pkg: ipmitool
+        smartmon:
+          enable: false
+          remove: false
+          pkg: smartmontools
+          bash_pkg: bash
+          smartctl: /usr/sbin/smartctl

--- a/prometheus/defaults.yaml
+++ b/prometheus/defaults.yaml
@@ -21,16 +21,21 @@ prometheus:
     var: /var/lib/prometheus
     args: /etc/default
     service: /usr/lib/systemd/system
+    textfile_collectors: /opt/prometheus/textfile_collectors
 
   service:
     prometheus:
       args:
         web.listen-address: 0.0.0.0:9090
     alertmanager: {}
+    node_exporter:
+      args:
+        collector.textfile.directory: /var/tmp/node_exporter
 
   config:
     prometheus: {}
     alertmanager: {}
+    node_exporter: {}
 
   pkg:
     prometheus:
@@ -113,3 +118,8 @@ prometheus:
 
   linux:
     altpriority: 0   ## 'Alternatives system' priority: zero disables (default)
+
+  exporters:
+    node_exporter:
+      textfile_collectors_dependencies: []
+      textfile_collectors: {}

--- a/prometheus/map.jinja
+++ b/prometheus/map.jinja
@@ -35,7 +35,13 @@
 {%-   if args|length > 0 %}
 {%-     for k,v in args -%}
 {%-       if not k or not v %}{% continue %}{% endif -%}
+{%-         if v == True -%}
+          --{{ k }}
+{%-         elif v == False -%}
+          --no-{{ k }}
+{%-         else -%}
           --{{ k }}={{ v }}
+{%-         endif -%}
 {%-       if not loop.last %} {% endif -%}
 {%-     endfor -%}
 {%-   endif -%}

--- a/prometheus/osfamilymap.yaml
+++ b/prometheus/osfamilymap.yaml
@@ -68,6 +68,11 @@ FreeBSD:
       archive_hash: ebcd21dc25e439eed64559e89cd7da9a94073d5ff321a8a3a4214ac2ebe04e34
     statsd_exporter:
       archive_hash: f345dff6311501f09bb5b6ba1128e925d504c6325ee97ad91a975f2be0d44da9
+  exporters:
+    node_exporter:
+      textfile_collectors:
+        smartmon:
+          smartctl: /usr/local/sbin/smartctl
 
 OpenBSD:
   rootgroup: wheel

--- a/prometheus/osfamilymap.yaml
+++ b/prometheus/osfamilymap.yaml
@@ -18,6 +18,10 @@ Debian:
   service:
     node_exporter:
       name: prometheus-node-exporter
+  exporters:
+    node_exporter:
+      textfile_collectors_dependencies:
+        - cron
 
 RedHat:
   pkg:

--- a/prometheus/osfamilymap.yaml
+++ b/prometheus/osfamilymap.yaml
@@ -40,7 +40,8 @@ Alpine: {}
 FreeBSD:
   rootgroup: wheel
   dir:
-    config: /usr/local/etc
+    args: false
+    etc: /usr/local/etc/prometheus
   pkg:
     prometheus:
       archive_hash: 94a63f14baeadab2f17b5ae0bbeda6688e6d06f964ef4e32c2954a0ecf3996a1

--- a/prometheus/package/install.sls
+++ b/prometheus/package/install.sls
@@ -16,7 +16,7 @@ include:
 
 prometheus-package-install-{{ name }}-installed:
   pkg.installed:
-    - name: {{ name }}
+    - name: {{ prometheus.pkg.get(name, {}).get('name', name) }}
 
         {%- endif %}
     {%- endfor %}

--- a/prometheus/service/running.sls
+++ b/prometheus/service/running.sls
@@ -11,6 +11,7 @@ include:
   - {{ sls_config_args }}
   - {{ sls_config_file }}
 
+    {%- if 'prometheus' in prometheus.wanted %}
 prometheus-config-file-var-file-directory:
   file.directory:
     - name: {{ prometheus.dir.var }}
@@ -20,6 +21,7 @@ prometheus-config-file-var-file-directory:
     - makedirs: True
     - require:
       - file: prometheus-config-file-etc-file-directory
+    {%- endif %}
 
     {%- for name in prometheus.wanted %}
         {%- if name in prometheus.service %}
@@ -34,8 +36,10 @@ prometheus-config-file-var-file-directory:
 prometheus-service-running-{{ name }}-service-unmasked:
   service.unmasked:
     - name: {{ service_name }}
+                {%- if 'prometheus' in prometheus.wanted %}
     - require:
       - file: prometheus-config-file-var-file-directory
+                {%- endif %}
     - onlyif:
        -  systemctl list-units | grep {{ service_name }} >/dev/null 2>&1
             {%- endif %}
@@ -48,8 +52,10 @@ prometheus-service-running-{{ name }}-service-running:
     - watch:
       - file: prometheus-config-file-{{ name }}-file-managed
             {%- endif %}
+            {%- if 'prometheus' in prometheus.wanted %}
     - require:
       - file: prometheus-config-file-var-file-directory
+            {%- endif %}
             {%- if grains.kernel|lower == 'linux' %}
       - service: prometheus-service-running-{{ name }}-service-unmasked
     - onlyif: systemctl list-units | grep {{ service_name }} >/dev/null 2>&1

--- a/test/integration/default/controls/config_spec.rb
+++ b/test/integration/default/controls/config_spec.rb
@@ -11,4 +11,10 @@ control 'Prometheus configuration' do
     its('content') { should include 'global:' }
     its('content') { should include 'alerting:' }
   end
+
+  describe file('/opt/prometheus/textfile_collectors/ipmitool') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    its('mode') { should cmp '0755' }
+  end
 end


### PR DESCRIPTION
- support for FreeBSD
- some minor bugfixes
- support using node exporter without prometheus user
- support for node exporter's textfile collectors
  - IPMI
  - smartmon
  - It's easy to add custom textfile collectors.

Tested with

- FreeBSD 11.3
- Ubuntu 16.04