### PR TITLE
fix(debian): add some valid defaults

### DIFF
--- a/prometheus/archive/install.sls
+++ b/prometheus/archive/install.sls
@@ -82,11 +82,9 @@ prometheus-archive-install-{{ name }}-file-directory:
       - user: prometheus-config-user-install-{{ name }}-user-present
       - group: prometheus-config-user-install-{{ name }}-user-present
 
-            {%- if grains.kernel|lower == 'linux' and 'config_file' in p.pkg.component[name] %}
-
 prometheus-archive-install-{{ name }}-managed-service:
   file.managed:
-    - name: {{ p.dir.service }}/{{ name }}.service
+    - name: {{ p.dir.service }}/{{ p.pkg.component[name]['service'].get('name', name) }}.service
     - source: {{ files_switch(['systemd.ini.jinja'],
                               lookup='prometheus-archive-install-' ~  name ~ '-managed-service'
                  )
@@ -103,7 +101,7 @@ prometheus-archive-install-{{ name }}-managed-service:
         group: {{ name }}
         workdir: {{ p.dir.var }}/{{ name }}
         stop: ''
-               {%- if name in ('node_exporter',) %}
+               {%- if name in ('node_exporter', 'consul_exporter') %}
         start: {{ p.pkg.component[name]['path'] }}/{{ name }}
                {%- else %}
         start: {{ p.pkg.component[name]['path'] }}/{{ name }} --config.file {{ p.pkg.component[name]['config_file'] }}  # noqa 204
@@ -118,6 +116,5 @@ prometheus-archive-install-{{ name }}-managed-service:
     - require:
       - archive: prometheus-archive-install-{{ name }}
 
-            {%- endif %}
         {%- endif %}
     {%- endfor %}

--- a/prometheus/archive/install.sls
+++ b/prometheus/archive/install.sls
@@ -103,7 +103,7 @@ prometheus-archive-install-{{ name }}-managed-service:
         group: {{ name }}
         workdir: {{ p.dir.var }}/{{ name }}
         stop: ''
-               {%- if name in ('node_exporter', 'consul_exporter') %}
+               {%- if name in ('node_exporter', 'consul_exporter') or 'config_file' not in p.pkg.component[name] %}
         start: {{ p.pkg.component[name]['path'] }}/{{ name }}
                {%- else %}
         start: {{ p.pkg.component[name]['path'] }}/{{ name }} --config.file {{ p.pkg.component[name]['config_file'] }}  # noqa 204

--- a/prometheus/archive/install.sls
+++ b/prometheus/archive/install.sls
@@ -82,6 +82,8 @@ prometheus-archive-install-{{ name }}-file-directory:
       - user: prometheus-config-user-install-{{ name }}-user-present
       - group: prometheus-config-user-install-{{ name }}-user-present
 
+            {%- if grains.kernel|lower == 'linux' %}
+
 prometheus-archive-install-{{ name }}-managed-service:
   file.managed:
     - name: {{ p.dir.service }}/{{ p.pkg.component[name]['service'].get('name', name) }}.service
@@ -116,5 +118,6 @@ prometheus-archive-install-{{ name }}-managed-service:
     - require:
       - archive: prometheus-archive-install-{{ name }}
 
+            {%- endif %}
         {%- endif %}
     {%- endfor %}

--- a/prometheus/osfamilymap.yaml
+++ b/prometheus/osfamilymap.yaml
@@ -20,6 +20,8 @@ Arch: {}
 Alpine: {}
 
 Debian:
+  dir:
+    service: /lib/systemd/system
   pkg:
     deps:
       - cron
@@ -31,66 +33,108 @@ Debian:
         name: prometheus
       alertmanager:
         name: prometheus-alertmanager
+        service:
+          name: prometheus-alertmanager
+        args_file: /etc/default/prometheus-alertmanager
       apache_exporter:
         name: prometheus-apache-exporter
+        service:
+          name: prometheus-apache-exporter
+        args_file: /etc/default/prometheus-apache-exporter
       bind_exporter:
         name: prometheus-bind-exporter
+        args_file: /etc/default/prometheus-bind-exporter
       bird_exporter:
         name: prometheus-bird-exporter
+        args_file: /etc/default/prometheus-bird-exporter
       blackbox_exporter:
         name: prometheus-blackbox-exporter
+        service:
+          name: prometheus-blackbox-exporter
+        config_file: /etc/prometheus/blackbox.yml
       hacluster_exporter:
         name: prometheus-hacluster-exporter
+        args_file: /etc/default/prometheus-hacluster-exporter
       haproxy_exporter:
         name: prometheus-haproxy-exporter
+        args_file: /etc/default/prometheus-haproxy-exporter
       homeplug_exporter:
         name: prometheus-homeplug-exporter
+        args_file: /etc/default/prometheus-homeplug-exporter
       ipmi_exporter:
         name: prometheus-ipmi-exporter
+        args_file: /etc/default/prometheus-ipmi-exporter
       libvirt_exporter:
         name: prometheus-libvirt-exporter
+        args_file: /etc/default/prometheus-libvirt-exporter
       mailexporter:
         name: prometheus-mailexporter
+        args_file: /etc/default/prometheus-mailexporter
       mongodb_exporter:
         name: prometheus-mongodb-exporter
+        args_file: /etc/default/prometheus-mongodb-exporter
       mysqld_exporter:
         name: prometheus-mysqld-exporter
+        service:
+          name: prometheus-mysqld-exporter
+        args_file: /etc/default/prometheus-mysqld-exporter
       nginx_exporter:
         name: prometheus-nginx-exporter
+        service:
+          name: prometheus-nginx-exporter
+        args_file: /etc/default/prometheus-nginx-exporter
       nginx_vts_exporter:
         name: prometheus-nginx-vts-exporter
+        args_file: /etc/default/prometheus-nginx-vts-exporter
       node_exporter:
         name: prometheus-node-exporter
+        service:
+          name: prometheus-node-exporter
         args_file: /etc/default/prometheus-node-exporter
       node_exporter_collectors:
         name: prometheus-node-exporter-collectors
+        args_file: /etc/default/prometheus-node-exporter-collectors
       openstack_exporter:
         name: prometheus-openstack-exporter
+        args_file: /etc/default/prometheus-openstack-exporter
       pgbouncer_exporter:
         name: prometheus-pgbouncer-exporter
+        args_file: /etc/default/prometheus-pgbouncer-exporter
       postfix_exporter:
         name: prometheus-postfix-exporter
+        args_file: /etc/default/prometheus-postfix-exporter
       postgres_exporter:
         name: prometheus-postgres-exporter
+        service:
+          name: prometheus-postgres-exporter
+        args_file: /etc/default/prometheus-postgres-exporter
       process_exporter:
         name: prometheus-process-exporter
+        args_file: /etc/default/prometheus-process-exporter
       pushgateway:
         name: prometheus-pushgateway
+        args_file: /etc/default/prometheus-pushgateway
       snmp_exporter:
         name: prometheus-snmp-exporter
+        args_file: /etc/default/prometheus-snmp-exporter
       sql_exporter:
         name: prometheus-sql-exporter
+        args_file: /etc/default/prometheus-sql-exporter
       squid_exporter:
         name: prometheus-squid-exporter
+        args_file: /etc/default/prometheus-squid-exporter
       tplink_plug_exporter:
         name: prometheus-tplink-plug-exporter
+        args_file: /etc/default/prometheus-tplink-plug-exporter
       trafficserver_exporter:
         name: prometheus-trafficserver-exporter
+        args_file: /etc/default/prometheus-trafficserver-exporter
       varnish_exporter:
         name: prometheus-varnish-exporter
+        args_file: /etc/default/prometheus-varnish-exporter
       xmpp_alerts:
         name: prometheus-xmpp-alerts
-
+        args_file: /etc/default/prometheus-xmpp-alerts
 
   exporters:
     node_exporter:

--- a/test/integration/default/controls/archive_spec.rb
+++ b/test/integration/default/controls/archive_spec.rb
@@ -3,13 +3,14 @@
 control 'prometheus components' do
   title 'should be installed'
 
-  service_dir =
-    case platform[:family]
-    when 'debian'
-      '/lib/systemd/system'
-    else
-      '/usr/lib/systemd/system'
-    end
+  case platform[:family]
+  when 'debian'
+    service_dir = '/lib/systemd/system'
+    alert_manager_service = 'prometheus-alertmanager'
+  else
+    service_dir = '/usr/lib/systemd/system'
+    alert_manager_service = 'alertmanager'
+  end
 
   # describe package('cron') do
   #   it { should be_installed }  # not available on amazonlinux?
@@ -64,7 +65,7 @@ control 'prometheus components' do
     it { should exist }
     its('group') { should eq 'alertmanager' }
   end
-  describe file("#{service_dir}/alertmanager.service") do
+  describe file("#{service_dir}/#{alert_manager_service}.service") do
     it { should exist }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0644' }

--- a/test/integration/default/controls/archive_spec.rb
+++ b/test/integration/default/controls/archive_spec.rb
@@ -7,9 +7,11 @@ control 'prometheus components' do
   when 'debian'
     service_dir = '/lib/systemd/system'
     alert_manager_service = 'prometheus-alertmanager'
+    node_exporter_service = 'prometheus-node-exporter'
   else
     service_dir = '/usr/lib/systemd/system'
     alert_manager_service = 'alertmanager'
+    node_exporter_service = 'node_exporter'
   end
 
   # describe package('cron') do
@@ -82,7 +84,7 @@ control 'prometheus components' do
     it { should exist }
     its('group') { should eq 'node_exporter' }
   end
-  describe file("#{service_dir}/node_exporter.service") do
+  describe file("#{service_dir}/#{node_exporter_service}.service") do
     it { should exist }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0644' }

--- a/test/integration/default/controls/archive_spec.rb
+++ b/test/integration/default/controls/archive_spec.rb
@@ -3,6 +3,14 @@
 control 'prometheus components' do
   title 'should be installed'
 
+  service_dir =
+    case platform[:family]
+    when 'debian'
+      '/lib/systemd/system'
+    else
+      '/usr/lib/systemd/system'
+    end
+
   # describe package('cron') do
   #   it { should be_installed }  # not available on amazonlinux?
   # end
@@ -39,7 +47,7 @@ control 'prometheus components' do
     it { should exist }
     its('group') { should eq 'prometheus' }
   end
-  describe file('/usr/lib/systemd/system/prometheus.service') do
+  describe file("#{service_dir}/prometheus.service") do
     it { should exist }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0644' }
@@ -56,7 +64,7 @@ control 'prometheus components' do
     it { should exist }
     its('group') { should eq 'alertmanager' }
   end
-  describe file('/usr/lib/systemd/system/alertmanager.service') do
+  describe file("#{service_dir}/alertmanager.service") do
     it { should exist }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0644' }
@@ -73,7 +81,7 @@ control 'prometheus components' do
     it { should exist }
     its('group') { should eq 'node_exporter' }
   end
-  describe file('/usr/lib/systemd/system/node_exporter.service') do
+  describe file("#{service_dir}/node_exporter.service") do
     it { should exist }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0644' }

--- a/test/integration/default/controls/service_spec.rb
+++ b/test/integration/default/controls/service_spec.rb
@@ -1,39 +1,31 @@
 # frozen_string_literal: true
 
-control 'services with a consistent service name across distros' do
-  title 'should be running'
-
-  # we forced node_exporter's service name to `node_exporter` in the pillar,
-  # so its name will be the same across distros for this test
-  describe service('node_exporter') do
-    it { should be_enabled }
-    it { should be_running }
-  end
-
-  # node_exporter port
-  describe port(9100) do
-    it { should be_listening }
-  end
-end
-
 control 'services with a consistent service name on each distro' do
   title 'should be running'
 
-  # if we don't set a service name in the pillar,
-  # its name will be the same on each distro, no matter what the
-  # install method we choose
-
-  distro_service =
+  distro_services =
     case platform[:family]
     when 'debian'
-      'prometheus-blackbox-exporter'
+      %w[
+        prometheus
+        prometheus-alertmanager
+        prometheus-node-exporter
+        prometheus-blackbox-exporter
+      ]
     else
-      'blackbox_exporter'
+      %w[
+        prometheus
+        alertmanager
+        node_exporter
+        blackbox_exporter
+      ]
     end
 
-  describe service(distro_service) do
-    it { should be_enabled }
-    it { should be_running }
+  distro_services.each do |service|
+    describe service(service) do
+      it { should be_enabled }
+      it { should be_running }
+    end
   end
 
   # blackbox_exporter port

--- a/test/integration/default/controls/service_spec.rb
+++ b/test/integration/default/controls/service_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-control 'prometheus services' do
+control 'services with a consistent service name across distros' do
   title 'should be running'
 
+  # we forced node_exporter's service name to `node_exporter` in the pillar,
+  # so its name will be the same across distros for this test
   describe service('node_exporter') do
     it { should be_enabled }
     it { should be_running }
@@ -10,6 +12,50 @@ control 'prometheus services' do
 
   # node_exporter port
   describe port(9100) do
+    it { should be_listening }
+  end
+end
+
+control 'services with a consistent service name on each distro' do
+  title 'should be running'
+
+  # if we don't set a service name in the pillar,
+  # its name will be the same on each distro, no matter what the
+  # install method we choose
+
+  distro_service =
+    case platform[:family]
+    when 'debian'
+      'prometheus-blackbox-exporter'
+    else
+      'blackbox_exporter'
+    end
+
+  describe service(distro_service) do
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  # blackbox_exporter port
+  describe port(9115) do
+    it { should be_listening }
+  end
+end
+
+control 'services with any service name we want to give them' do
+  title 'should be running'
+
+  # if we set a service name in the pillar,
+  # the formula should work, no matter what it is or the
+  # install method we choose
+
+  describe service('my-fancy-consul-exporter-service') do
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  # consul_exporter port
+  describe port(9107) do
     it { should be_listening }
   end
 end

--- a/test/integration/repo/controls/service_spec.rb
+++ b/test/integration/repo/controls/service_spec.rb
@@ -3,17 +3,29 @@
 control 'prometheus services' do
   title 'should be running'
 
-  service =
+  services =
     case platform[:family]
     when 'redhat'
-      'node_exporter'
+      %w[
+        node_exporter
+        prometheus
+        blackbox_exporter
+        alertmanager
+      ]
     else
-      'prometheus-node-exporter'
+      %w[
+        prometheus
+        prometheus-node-exporter
+        prometheus-blackbox-exporter
+        prometheus-alertmanager
+      ]
     end
 
-  describe service(service) do
-    it { should be_enabled }
-    it { should be_running }
+  services.each do |service|
+    describe service(service) do
+      it { should be_enabled }
+      it { should be_running }
+    end
   end
 
   # prometheus-node-exporter port

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -13,6 +13,8 @@ prometheus:
       - prometheus
       - alertmanager
       - node_exporter
+      - blackbox_exporter
+      - consul_exporter
       # - memcached_exporter  # not in upstream repo, only archive
 
   exporters:
@@ -93,10 +95,20 @@ prometheus:
         archive:
           source_hash: b2503fd932f85f4e5baf161268854bf5d22001869b84f00fd2d1f57b51b72424
         service:
-          name: node_exporter
           args:
             web.listen-address: ":9110"
             # collector.textfile.directory: /var/tmp/node_exporter
+
+      blackbox_exporter:
+        service:
+          args:
+            web.listen-address: ":9115"
+        config_file: /opt/prometheus/blackbox_exporter-v0.14.0/blackbox.yml
+
+      consul_exporter:
+        service:
+          # This is to test that any fancy name we use, will work in archive mode
+          name: my-fancy-consul-exporter-service
 
       prometheus:
         service:

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -81,15 +81,6 @@ prometheus:
               email_configs:
                 - to: 'team-X+alerts@example.org'
 
-          inhibit_rules:
-            - name: opsGenie-receiver
-              opsgenie_configs:
-                - api_key: mysecret
-            - name: slack-receiver
-              slack_configs:
-                - channel: '#my-channel'
-                  image_url: 'http://some.img.com/img.png'
-
       node_exporter:
         version: v0.18.1
         archive:

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -93,7 +93,7 @@ prometheus:
         archive:
           source_hash: b2503fd932f85f4e5baf161268854bf5d22001869b84f00fd2d1f57b51b72424
         service:
-          # name: prometheus-node-exporter
+          name: node_exporter
           args:
             web.listen-address: ":9110"
             # collector.textfile.directory: /var/tmp/node_exporter

--- a/test/salt/pillar/repo.sls
+++ b/test/salt/pillar/repo.sls
@@ -12,7 +12,6 @@ prometheus:
       - alertmanager
       - node_exporter
       - blackbox_exporter
-      # - memcached_exporter  # not in upstream repo, only archive
 
   exporters:
     node_exporter:
@@ -72,20 +71,6 @@ prometheus:
               email_configs:
                 - to: 'team-X+alerts@example.org'
 
-          inhibit_rules:
-            - name: opsGenie-receiver
-              opsgenie_configs:
-                - api_key: mysecret
-            - name: slack-receiver
-              slack_configs:
-                - channel: '#my-channel'
-                  image_url: 'http://some.img.com/img.png'
-
-        {% if grains['os_family'] == 'Debian' %}
-        service:
-          name: prometheus-alertmanager
-        {% endif %}
-
       node_exporter:
         version: v0.18.1
         archive:
@@ -94,9 +79,11 @@ prometheus:
           args:
             web.listen-address: ":9110"
             # collector.textfile.directory: /var/tmp/node_exporter
-          {% if grains['os_family'] == 'Debian' %}
-          name: prometheus-node-exporter
-          {% endif %}
+
+      blackbox_exporter:
+        service:
+          args:
+            web.listen-address: ":9115"
 
       prometheus:
         service:


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [X] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

This should probably fix #42. Debian's family names have the format `prometheus-component-{exporter}` and the `systemd`' services path is not the one set in the defaults.

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Added a bunch of entries to manage some services and default files correctly for the Debian family.

Quite possibly, this can be better fixed in the `map.jinja` file in an automated way (add 'prometheus' to the packages names, replace underscores with dashes, etc.)

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


