### PR TITLE
feat(archive): allowing archive options to be overridable

### DIFF
--- a/prometheus/archive/install.sls
+++ b/prometheus/archive/install.sls
@@ -99,8 +99,8 @@ prometheus-archive-install-{{ name }}-file-directory:
     - name: {{ p.dir.var }}{{ p.div }}{{ name }}
     - makedirs: True
             {%- if grains.os != 'Windows' %}
-    - user: {{ name }}
-    - group: {{ name }}
+    - user: {{ name|truncate(32) }}
+    - group: {{ name|truncate(32) }}
     - mode: '0755'
     - require:
       - user: prometheus-config-users-install-{{ name }}-user-present
@@ -124,8 +124,8 @@ prometheus-archive-install-{{ name }}-managed-service:
     - context:
         desc: prometheus - {{ name }} service
         name: {{ name }}
-        user: {{ name }}
-        group: {{ name }}
+        user: {{ name|truncate(32) }}
+        group: {{ name|truncate(32) }}
         env: {{ p.pkg.component[name]['service'].get('env', [])|tojson }}
         workdir: {{ p.dir.var }}/{{ name }}
         stop: ''

--- a/prometheus/archive/install.sls
+++ b/prometheus/archive/install.sls
@@ -98,7 +98,7 @@ prometheus-archive-install-{{ name }}-file-directory:
     - name: {{ p.dir.var }}{{ p.div }}{{ name }}
     - makedirs: True
             {%- if grains.os != 'Windows' %}
-    - user: {{ name|truncate(32, False, "") }}
+    - user: {{ name|truncate(16, False, "") }}
     - group: {{ name|truncate(16, False, "") }}
     - mode: '0755'
     - require:
@@ -123,7 +123,7 @@ prometheus-archive-install-{{ name }}-managed-service:
     - context:
         desc: prometheus - {{ name }} service
         name: {{ name }}
-        user: {{ name|truncate(32, False, "") }}
+        user: {{ name|truncate(16, False, "") }}
         group: {{ name|truncate(16, False, "") }}
         env: {{ p.pkg.component[name]['service'].get('env', [])|tojson }}
         workdir: {{ p.dir.var }}/{{ name }}

--- a/prometheus/archive/install.sls
+++ b/prometheus/archive/install.sls
@@ -47,7 +47,6 @@ prometheus-archive-install-{{ name }}:
     {{- format_kwargs(p.pkg.component[name]['archive']) }}
     - trim_output: true
     - enforce_toplevel: false
-    - options: --strip-components=1
     - force: {{ p.force }}
     - retry: {{ p.retry_option|json }}
     - require:

--- a/prometheus/archive/install.sls
+++ b/prometheus/archive/install.sls
@@ -98,8 +98,8 @@ prometheus-archive-install-{{ name }}-file-directory:
     - name: {{ p.dir.var }}{{ p.div }}{{ name }}
     - makedirs: True
             {%- if grains.os != 'Windows' %}
-    - user: {{ name|truncate(32) }}
-    - group: {{ name|truncate(32) }}
+    - user: {{ name|truncate(32, False, "") }}
+    - group: {{ name|truncate(16, False, "") }}
     - mode: '0755'
     - require:
       - user: prometheus-config-users-install-{{ name }}-user-present
@@ -123,8 +123,8 @@ prometheus-archive-install-{{ name }}-managed-service:
     - context:
         desc: prometheus - {{ name }} service
         name: {{ name }}
-        user: {{ name|truncate(32) }}
-        group: {{ name|truncate(32) }}
+        user: {{ name|truncate(32, False, "") }}
+        group: {{ name|truncate(16, False, "") }}
         env: {{ p.pkg.component[name]['service'].get('env', [])|tojson }}
         workdir: {{ p.dir.var }}/{{ name }}
         stop: ''

--- a/prometheus/config/clean.sls
+++ b/prometheus/config/clean.sls
@@ -19,12 +19,12 @@ prometheus-config-clean-{{ name }}:
     - name: {{ name }}_environ
              {%- endif %}
   user.absent:
-    - name: {{ name|truncate(32) }}
+    - name: {{ name|truncate(32, False, "") }}
                 {%- if grains.os_family == 'MacOS' %}
     - onlyif: /usr/bin/dscl . list /Users | grep {{ name }} >/dev/null 2>&1
                 {%- endif %}
   group.absent:
-    - name: {{ name|truncate(32) }}
+    - name: {{ name|truncate(16, False, "") }}
     - require:
        - {{ sls_config_clean }}
 

--- a/prometheus/config/clean.sls
+++ b/prometheus/config/clean.sls
@@ -19,12 +19,12 @@ prometheus-config-clean-{{ name }}:
     - name: {{ name }}_environ
              {%- endif %}
   user.absent:
-    - name: {{ name }}
+    - name: {{ name|truncate(32) }}
                 {%- if grains.os_family == 'MacOS' %}
     - onlyif: /usr/bin/dscl . list /Users | grep {{ name }} >/dev/null 2>&1
                 {%- endif %}
   group.absent:
-    - name: {{ name }}
+    - name: {{ name|truncate(32) }}
     - require:
        - {{ sls_config_clean }}
 

--- a/prometheus/config/clean.sls
+++ b/prometheus/config/clean.sls
@@ -19,7 +19,7 @@ prometheus-config-clean-{{ name }}:
     - name: {{ name }}_environ
              {%- endif %}
   user.absent:
-    - name: {{ name|truncate(32, False, "") }}
+    - name: {{ name|truncate(16, False, "") }}
                 {%- if grains.os_family == 'MacOS' %}
     - onlyif: /usr/bin/dscl . list /Users | grep {{ name }} >/dev/null 2>&1
                 {%- endif %}

--- a/prometheus/config/users.sls
+++ b/prometheus/config/users.sls
@@ -8,16 +8,16 @@
 
 prometheus-config-users-install-{{ name }}-group-present:
   group.present:
-    - name: {{ name }}
+    - name: {{ name|truncate(32) }}
     - system: true
     - require_in:
       - user: prometheus-config-users-install-{{ name }}-user-present
 
 prometheus-config-users-install-{{ name }}-user-present:
   user.present:
-    - name: {{ name }}
+    - name: {{ name|truncate(32) }}
     - groups:
-      - {{ name }}
+      - {{ name|truncate(32) }}
               {%- if grains.os != 'Windows' %}
     - shell: {{ p.shell }}
                   {%- if grains.kernel|lower == 'linux' %}

--- a/prometheus/config/users.sls
+++ b/prometheus/config/users.sls
@@ -15,7 +15,7 @@ prometheus-config-users-install-{{ name }}-group-present:
 
 prometheus-config-users-install-{{ name }}-user-present:
   user.present:
-    - name: {{ name|truncate(32, False, "") }}
+    - name: {{ name|truncate(16, False, "") }}
     - groups:
       - {{ name|truncate(16, False, "") }}
               {%- if grains.os != 'Windows' %}

--- a/prometheus/config/users.sls
+++ b/prometheus/config/users.sls
@@ -8,16 +8,16 @@
 
 prometheus-config-users-install-{{ name }}-group-present:
   group.present:
-    - name: {{ name|truncate(32) }}
+    - name: {{ name|truncate(16, False, "") }}
     - system: true
     - require_in:
       - user: prometheus-config-users-install-{{ name }}-user-present
 
 prometheus-config-users-install-{{ name }}-user-present:
   user.present:
-    - name: {{ name|truncate(32) }}
+    - name: {{ name|truncate(32, False, "") }}
     - groups:
-      - {{ name|truncate(32) }}
+      - {{ name|truncate(16, False, "") }}
               {%- if grains.os != 'Windows' %}
     - shell: {{ p.shell }}
                   {%- if grains.kernel|lower == 'linux' %}

--- a/prometheus/exporters/node_exporter/textfile_collectors/init.sls
+++ b/prometheus/exporters/node_exporter/textfile_collectors/init.sls
@@ -18,7 +18,7 @@ prometheus-exporters-{{ name }}-collector-textfile-dir:
     - name: {{ p.pkg.component[name]['service']['args']['collector.textfile.directory'] }}
         {%- if grains.os != 'Windows' %}
     - mode: 755
-    - user: {{ name|truncate(32, False, "") }}
+    - user: {{ name|truncate(16, False, "") }}
     - group: {{ name|truncate(16, False, "") }}
         {%- endif %}
     - makedirs: True

--- a/prometheus/exporters/node_exporter/textfile_collectors/init.sls
+++ b/prometheus/exporters/node_exporter/textfile_collectors/init.sls
@@ -18,8 +18,8 @@ prometheus-exporters-{{ name }}-collector-textfile-dir:
     - name: {{ p.pkg.component[name]['service']['args']['collector.textfile.directory'] }}
         {%- if grains.os != 'Windows' %}
     - mode: 755
-    - user: {{ name }}
-    - group: {{ name }}
+    - user: {{ name|truncate(32) }}
+    - group: {{ name|truncate(32) }}
         {%- endif %}
     - makedirs: True
     - require:

--- a/prometheus/exporters/node_exporter/textfile_collectors/init.sls
+++ b/prometheus/exporters/node_exporter/textfile_collectors/init.sls
@@ -18,8 +18,8 @@ prometheus-exporters-{{ name }}-collector-textfile-dir:
     - name: {{ p.pkg.component[name]['service']['args']['collector.textfile.directory'] }}
         {%- if grains.os != 'Windows' %}
     - mode: 755
-    - user: {{ name|truncate(32) }}
-    - group: {{ name|truncate(32) }}
+    - user: {{ name|truncate(32, False, "") }}
+    - group: {{ name|truncate(16, False, "") }}
         {%- endif %}
     - makedirs: True
     - require:

--- a/prometheus/map.jinja
+++ b/prometheus/map.jinja
@@ -29,6 +29,7 @@
     {%- for name,v in p.pkg.component.items() %}
         {%- set url = None %}
         {%- set dir = name %}
+        {%- do p.pkg.component[name].get('archive', {}).setdefault('options', '--strip-components=1') %}
         {%- if 'version' in v and v.version and 'archive' in v and v.archive and 'uri' in p.pkg %}
             {%- set uri = '%s/%s/releases/download/%s/%s'|format(p.pkg.uri, name, v.version, name) %}
             {%- set url = '%s-%s.%s-%s.tar.gz'|format(uri, v.version|replace('v',''), p.kernel, p.arch) %}

--- a/prometheus/service/args/install.sls
+++ b/prometheus/service/args/install.sls
@@ -25,8 +25,8 @@ include:
 prometheus-service-args-{{ name }}-data-dir:
   file.directory:
     - name: {{ args['storage.tsdb.path'] }}
-    - user: {{ name }}
-    - group: {{ name }}
+    - user: {{ name|truncate(32) }}
+    - group: {{ name|truncate(32) }}
     - makedirs: True
     - watch_in:
       - service: prometheus-service-running-{{ name }}

--- a/prometheus/service/args/install.sls
+++ b/prometheus/service/args/install.sls
@@ -25,8 +25,8 @@ include:
 prometheus-service-args-{{ name }}-data-dir:
   file.directory:
     - name: {{ args['storage.tsdb.path'] }}
-    - user: {{ name|truncate(32) }}
-    - group: {{ name|truncate(32) }}
+    - user: {{ name|truncate(32, False, "") }}
+    - group: {{ name|truncate(16, False, "") }}
     - makedirs: True
     - watch_in:
       - service: prometheus-service-running-{{ name }}

--- a/prometheus/service/args/install.sls
+++ b/prometheus/service/args/install.sls
@@ -25,7 +25,7 @@ include:
 prometheus-service-args-{{ name }}-data-dir:
   file.directory:
     - name: {{ args['storage.tsdb.path'] }}
-    - user: {{ name|truncate(32, False, "") }}
+    - user: {{ name|truncate(16, False, "") }}
     - group: {{ name|truncate(16, False, "") }}
     - makedirs: True
     - watch_in:

--- a/test/integration/default/controls/archive_spec.rb
+++ b/test/integration/default/controls/archive_spec.rb
@@ -56,7 +56,7 @@ control 'prometheus components' do
   describe group('prometheus_bigqu') do
     it { should exist }
   end
-  describe user('prometheus_bigquery_remote_stora') do
+  describe user('prometheus_bigqu') do
     it { should exist }
   end
   describe directory('/var/lib/prometheus') do

--- a/test/integration/default/controls/archive_spec.rb
+++ b/test/integration/default/controls/archive_spec.rb
@@ -53,10 +53,10 @@ control 'prometheus components' do
   describe user('mysqld_exporter') do
     it { should exist }
   end
-  describe group('prometheus_bigquery_remote_st...') do
+  describe group('prometheus_bigqu') do
     it { should exist }
   end
-  describe user('prometheus_bigquery_remote_st...') do
+  describe user('prometheus_bigquery_remote_stora') do
     it { should exist }
   end
   describe directory('/var/lib/prometheus') do
@@ -173,7 +173,7 @@ control 'prometheus components' do
   end
   describe directory('/var/lib/prometheus/prometheus_bigquery_remote_storage_adapter') do # rubocop:disable Layout/LineLength
     it { should exist }
-    its('group') { should eq 'prometheus_bigquery_remote_st...' }
+    its('group') { should eq 'prometheus_bigqu' }
   end
   describe file("#{service_dir}/prometheus-bigquery-backend.service") do
     it { should exist }

--- a/test/integration/default/controls/archive_spec.rb
+++ b/test/integration/default/controls/archive_spec.rb
@@ -53,6 +53,12 @@ control 'prometheus components' do
   describe user('mysqld_exporter') do
     it { should exist }
   end
+  describe group('prometheus_bigquery_remote_st...') do
+    it { should exist }
+  end
+  describe user('prometheus_bigquery_remote_st...') do
+    it { should exist }
+  end
   describe directory('/var/lib/prometheus') do
     it { should exist }
   end
@@ -154,6 +160,23 @@ control 'prometheus components' do
   describe file("#{service_dir}/#{mysqld_exporter_service}.service") do
     it { should exist }
     its('content') { should match 'Environment=DATA_SOURCE_NAME=foo:bar@/' }
+    its('group') { should eq 'root' }
+    its('mode') { should cmp '0644' }
+  end
+  describe directory('/opt/prometheus/prometheus_bigquery_remote_storage_adapter-v0.4.6') do # rubocop:disable Layout/LineLength
+    it { should exist }
+    its('group') { should eq 'root' }
+  end
+  describe file('/opt/prometheus/prometheus_bigquery_remote_storage_adapter-v0.4.6/prometheus_bigquery_remote_storage_adapter') do # rubocop:disable Layout/LineLength
+    it { should exist }
+    its('group') { should eq 'root' }
+  end
+  describe directory('/var/lib/prometheus/prometheus_bigquery_remote_storage_adapter') do # rubocop:disable Layout/LineLength
+    it { should exist }
+    its('group') { should eq 'prometheus_bigquery_remote_st...' }
+  end
+  describe file("#{service_dir}/prometheus-bigquery-backend.service") do
+    it { should exist }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0644' }
   end

--- a/test/integration/default/controls/service_spec.rb
+++ b/test/integration/default/controls/service_spec.rb
@@ -11,7 +11,6 @@ control 'services with a consistent service name on each distro' do
         prometheus-alertmanager
         prometheus-node-exporter
         prometheus-blackbox-exporter
-        prometheus-bigquery-backend
       ]
     else
       %w[
@@ -19,7 +18,6 @@ control 'services with a consistent service name on each distro' do
         alertmanager
         node_exporter
         blackbox_exporter
-        prometheus-bigquery-backend
       ]
     end
 
@@ -51,5 +49,13 @@ control 'services with any service name we want to give them' do
   # consul_exporter port
   describe port(9107) do
     it { should be_listening }
+  end
+end
+
+control 'services that should be enabled but not running' do
+  title 'should be enabled'
+  describe service('prometheus-bigquery-backend') do
+    it { should be_enabled }
+    it { should_not be_running }
   end
 end

--- a/test/integration/default/controls/service_spec.rb
+++ b/test/integration/default/controls/service_spec.rb
@@ -51,11 +51,3 @@ control 'services with any service name we want to give them' do
     it { should be_listening }
   end
 end
-
-control 'services that should be enabled but not running' do
-  title 'should be enabled'
-  describe service('prometheus-bigquery-backend') do
-    it { should be_enabled }
-    it { should_not be_running }
-  end
-end

--- a/test/integration/default/controls/service_spec.rb
+++ b/test/integration/default/controls/service_spec.rb
@@ -11,6 +11,7 @@ control 'services with a consistent service name on each distro' do
         prometheus-alertmanager
         prometheus-node-exporter
         prometheus-blackbox-exporter
+        prometheus-bigquery-backend
       ]
     else
       %w[
@@ -18,6 +19,7 @@ control 'services with a consistent service name on each distro' do
         alertmanager
         node_exporter
         blackbox_exporter
+        prometheus-bigquery-backend
       ]
     end
 

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -20,6 +20,7 @@ prometheus:
       - postgres_exporter
       - mysqld_exporter
       - memcached_exporter  # not in upstream repo, only archive
+      - prometheus_bigquery_remote_storage_adapter
 
   exporters:
     node_exporter:
@@ -217,6 +218,22 @@ prometheus:
           # yamllint disable-line rule:line-length
           source: https://github.com/wrouesnel/postgres_exporter/releases/download/v0.8.0/postgres_exporter_v0.8.0_linux-amd64.tar.gz
           skip_verify: true
+
+      prometheus_bigquery_remote_storage_adapter:
+        version: v0.4.6
+        service:
+          name: prometheus-bigquery-backend
+          env:
+            - "PROMBQ_DATASET=prometheus"
+            - "PROMBQ_TABLE=metrics_stream"
+            - "PROMBQ_GCP_PROJECT_ID=foobar"
+        archive:
+          official: false
+          name: /opt/prometheus/prometheus_bigquery_remote_storage_adapter
+          options: "--strip-components=0"
+          source: https://github.com/KohlsTechnology/prometheus_bigquery_remote_storage_adapter/releases/download/v0.4.6/prometheus_bigquery_remote_storage_adapter_0.4.6_Linux_x86_64.tar.gz # noqa: 204
+          source_hash: https://github.com/KohlsTechnology/prometheus_bigquery_remote_storage_adapter/releases/download/v0.4.6/checksums.txt
+          source_hash_name: prometheus_bigquery_remote_storage_adapter_0.4.6_Linux_x86_64.tar.gz
 
   linux:
     # 'Alternatives system' priority: zero disables (default)


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

- fix(usernames): Truncating user/group names to 32 characters (linux limit)
- feat(archive): Allowing archive options to be overridable

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [x] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


