### PR TITLE
Support for SUSE packages

### DIFF
--- a/prometheus/config/storage.sls
+++ b/prometheus/config/storage.sls
@@ -24,9 +24,11 @@ prometheus-service-args-{{ name }}-data-dir:
     - makedirs: True
     - watch_in:
       - service: prometheus-service-running-{{ name }}
+            {%- if p.manage_user_group %}
     - require:
       - user: prometheus-config-users-install-{{ name }}-user-present
       - group: prometheus-config-users-install-{{ name }}-group-present
+            {%- endif %}
 
             {%- endif %}
         {% endif %}

--- a/prometheus/config/users.sls
+++ b/prometheus/config/users.sls
@@ -4,6 +4,7 @@
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import prometheus as p with context %}
 
+  {%- if p.manage_user_group or p.pkg.use_upstream_archive %}
   {%- for name in p.wanted.component %}
 
 prometheus-config-users-install-{{ name }}-group-present:
@@ -29,3 +30,4 @@ prometheus-config-users-install-{{ name }}-user-present:
               {%- endif %}
 
   {%- endfor %}
+  {%- endif %}

--- a/prometheus/defaults.yaml
+++ b/prometheus/defaults.yaml
@@ -23,6 +23,8 @@ prometheus:
     tmp: /tmp/prometheus
     var: /var/lib/prometheus
 
+  manage_user_group: true
+
   pkg:
     uri: https://github.com/prometheus
     use_upstream_repo: false

--- a/prometheus/exporters/node_exporter/textfile_collectors/init.sls
+++ b/prometheus/exporters/node_exporter/textfile_collectors/init.sls
@@ -22,9 +22,11 @@ prometheus-exporters-{{ name }}-collector-textfile-dir:
     - group: {{ name }}
         {%- endif %}
     - makedirs: True
+            {%- if p.manage_user_group %}
     - require:
       - user: prometheus-config-users-install-{{ name }}-user-present
       - group: prometheus-config-users-install-{{ name }}-group-present
+            {%- endif %}
     {%- endif %}
 
 {%- for k, v in p.get('exporters', {}).get(name, {}).get('textfile_collectors', {}).items() %}

--- a/prometheus/files/default/environ.sh.jinja
+++ b/prometheus/files/default/environ.sh.jinja
@@ -2,7 +2,7 @@
 # File managed by Salt at <{{ source }}>.
 # Your changes may be overwritten.
 ########################################################################
-# Set the command-line arguments to pass to the server.%}"
+# Set the command-line arguments to pass to the server."
 {{ arg_name }}="{{ args }}"
 
 

--- a/prometheus/osfamilymap.yaml
+++ b/prometheus/osfamilymap.yaml
@@ -219,7 +219,66 @@ RedHat:
       sslcacert: /etc/pki/tls/certs/ca-bundle.crt
       metadata_expire: 300
 
-Suse: {}
+Suse:
+  manage_user_group: false
+  pkg:
+    use_upstream_repo: false
+    use_upstream_package: false
+    use_upstream_archive: false
+    component:
+      alertmanager:
+        name: golang-github-prometheus-alertmanager
+        service:
+          name: prometheus-alertmanager
+        environ_file: /etc/sysconfig/prometheus-alertmanager
+        args:
+            config.file: /etc/prometheus/alertmanager.yml
+        config_file: /etc/prometheus/alertmanager.yml
+      prometheus:
+        name: golang-github-prometheus-prometheus
+        service:
+          name: prometheus
+        environ_file: /etc/sysconfig/prometheus
+        environ:
+          environ_arg_name: ARGS
+        config_file: /etc/prometheus/prometheus.yml
+      blackbox_exporter:
+        name: prometheus-blackbox_exporter
+        config_file: /etc/prometheus/blackbox.yml
+        service:
+          name: prometheus-blackbox_exporter
+      hacluster_exporter:
+        name: prometheus-ha_cluster_exporter
+        environ_file: /etc/sysconfig/prometheus-ha_cluster_exporter
+        environ:
+          environ_arg_name: ARGS
+        service:
+          name: prometheus-ha_cluster_exporter
+      node_exporter:
+        name: golang-github-prometheus-node_exporter
+        service:
+          name: prometheus-node_exporter
+        environ_file: /etc/sysconfig/prometheus-node_exporter
+        environ:
+          environ_arg_name: ARGS
+      postgres_exporter:
+        name: prometheus-postgres_exporter
+        service:
+          name: prometheus-postgres_exporter
+        environ_file: /etc/sysconfig/prometheus-postgres_exporter
+        environ:
+          environ_arg_name: POSTGRES_EXPORTER_PARAMS
+      saptune_exporter:
+        name: prometheus-saptune_exporter
+        service:
+          name: prometheus-saptune_exporter
+      webhook_snmp:
+        name: prometheus-webhook-snmp
+        service:
+          name: prometheus-webhook-snmp
+        environ_file: /etc/default/prometheus-webhook-snmp
+        environ:
+          environ_arg_name: PROMETHEUS_WEBHOOK_SNMP_OPTIONS
 
 Gentoo:
   pkg:

--- a/prometheus/service/args/install.sls
+++ b/prometheus/service/args/install.sls
@@ -30,9 +30,11 @@ prometheus-service-args-{{ name }}-data-dir:
     - makedirs: True
     - watch_in:
       - service: prometheus-service-running-{{ name }}
+            {%- if p.manage_user_group %}
     - require:
       - user: prometheus-config-users-install-{{ name }}-user-present
       - group: prometheus-config-users-install-{{ name }}-group-present
+            {%- endif %}
 
             {%- endif %}
             {%- if grains.os_family == 'FreeBSD' %}

--- a/test/salt/pillar/repo.sls
+++ b/test/salt/pillar/repo.sls
@@ -13,6 +13,12 @@ prometheus:
       - alertmanager
       - node_exporter
       - blackbox_exporter
+      {%- if grains.os == 'SUSE' %}
+      - hacluster_exporter
+      - postgres_exporter
+      - saptune_exporter
+      - webhook_snmp
+      {%- endif %}
 
   exporters:
     node_exporter:
@@ -31,7 +37,7 @@ prometheus:
 
   pkg:
     # yamllint disable-line rule:braces rule:commas
-    use_upstream_repo: {{ false if grains.os_family|lower in ('debian',) else true }}
+    use_upstream_repo: {{ false if grains.os_family|lower in ('debian','suse',) else true }}
     use_upstream_archive: false
 
     clientlibs:


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

Add support for openSUSE Leap and SUSE Linux Enterprise.

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

- add correct package names and configuration file paths to map
- add logic to prevent formula from changing users and groups managed by system packages

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

```
prometheus:
  wanted:
    component:
      - prometheus
      - alertmanager
      - node_exporter
      - blackbox_exporter
      - hacluster_exporter
      - postgres_exporter
      - saptune_exporter
      - webhook_snmp
  exporters:
    node_exporter:
      textfile_collectors:
        ipmitool:
          enable: true

  pkg:
    component:
      alertmanager:
        config:
          global:
            smtp_smarthost: foo:465
      node_exporter:
        environ:
          args:
            web.listen-address: ':9220'
      prometheus:
        environ:
          args:
            web.listen-address: ':9330'
        config:
          global:
            scrape_interval: 30s
      webhook_snmp:
        environ:
          args:
            snmp-port: ':1234'
      hacluster_exporter:
        environ:
          args:
            web.listen-address: ':9330'
      postgres_exporter:
        environ:
          args:
            web.listen-address: ':9330'
```


### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

GitHub blocks me from adding such long output. You can find it for three months on https://paste.opensuse.org/pastes/4007f64cfce4.

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->

Used the opportunity to remove the trailing `%}` characters from the environment file template.